### PR TITLE
changing version of org.scijava to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>parsington</artifactId>
+			<version>2.0.0</version>
 		</dependency>
 
 		<!-- Third-party dependencies -->


### PR DESCRIPTION
Built project with mvn clean install, but some failure is shown.
Used mvn versions:display-dependency-updates to check recent version changes.
Edited pom.xml, adding a line <version>2.0.0</version> to org.scijava (2.0.0 is the last version).

All actions are done with Java 8 JDK with JavaFX.